### PR TITLE
Triying to fix mac error with Rscript path

### DIFF
--- a/src/main/java/tappas/DataApp.java
+++ b/src/main/java/tappas/DataApp.java
@@ -202,7 +202,8 @@ public class DataApp extends AppObject {
     public static final String RESULTS_GENE_PROT = "result_gene_prot.tsv";
 
     // class data
-    private final String appRunPath = System.getProperty("user.dir");
+    //private final String appRunPath = System.getProperty("user.dir");
+    private final String appRunPath = Paths.get(System.getProperty("user.home"), ".tappas").toString();
     private String appBaseFolder;
     private String appProjectsBaseFolder;
     private String appFolder = "";
@@ -216,7 +217,7 @@ public class DataApp extends AppObject {
         try {
             if(Files.exists(Paths.get(getRScriptOverwriteFilepath()))) {
                 List<String> lines = Files.readAllLines(Paths.get(getRScriptOverwriteFilepath()), StandardCharsets.UTF_8);
-                String rscriptPath = "";
+                //String rscriptPath = "";
                 if(lines != null && lines.size() == 1) {
                     // get full path from user defined entry
                     // deal with windows and spaces in name, e.g. "Program Files"


### PR DESCRIPTION
This pull request updates the way the application determines its runtime path and includes a minor code cleanup. The most significant change is that the application now uses a dedicated directory in the user's home folder for its runtime path, which improves user data management and avoids cluttering the working directory.

**Application path management:**

* Changed the initialization of `appRunPath` in `DataApp.java` to use a `.tappas` directory in the user's home folder instead of the current working directory. This helps keep application files organized and user-specific.

**Code cleanup:**

* Commented out an unused variable assignment (`rscriptPath`) in the `loadRscriptPath` method for clarity.